### PR TITLE
update config in `volt.toml`

### DIFF
--- a/volt.toml
+++ b/volt.toml
@@ -23,6 +23,6 @@ description = "Whether to show native rust-analyzer diagnostics."
 default = true
 description = "Whether to show native rust-analyzer diagnostics."
 
-[config."checkOnSave.command"]
+[config."check.command"]
 default = "check"
 description = "Cargo command to use for `cargo check`."


### PR DESCRIPTION
as of the latest version of `rust-analyzer`, the option `checkOnSave.command` has been changed to `check.command`. this change has been reflected in this pull request.